### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-talos-version.yaml
+++ b/.github/workflows/update-talos-version.yaml
@@ -1,5 +1,10 @@
 name: Update Talos Version
 
+permissions:
+  contents: read
+  id-token: write
+  secrets: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/kreatoo/bouquet2/security/code-scanning/5](https://github.com/kreatoo/bouquet2/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Based on the operations in the workflow, the following permissions are necessary:
- `contents: read` to read repository files like `vars.yaml`.
- `id-token: write` for authentication with external services using OIDC tokens.
- `secrets: read` to access secrets like `TALOSCONFIG` and `KUBECONFIG`.

This change will ensure that the workflow only has the permissions it needs to function correctly, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
