### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/k8s-static-val.yaml
+++ b/.github/workflows/k8s-static-val.yaml
@@ -1,4 +1,6 @@
 name: Kubernetes Static Validation
+permissions:
+  contents: read
 on:
   workflow_call:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/kreatoo/bouquet2/security/code-scanning/2](https://github.com/kreatoo/bouquet2/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it primarily needs `contents: read` to access the repository's files. No write permissions are necessary.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
