### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -1,6 +1,8 @@
 name: Deploy
 on:
   workflow_call:
+permissions:
+  contents: read
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kreatoo/bouquet2/security/code-scanning/1](https://github.com/kreatoo/bouquet2/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, it appears that the workflow primarily reads repository contents and does not perform any write operations. Therefore, we will set `contents: read` as the permission. This ensures that the workflow has only the necessary permissions and adheres to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
