### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup-environment.yaml
+++ b/.github/workflows/setup-environment.yaml
@@ -12,6 +12,9 @@ on:
       TS_OAUTH_SECRET:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kreatoo/bouquet2/security/code-scanning/6](https://github.com/kreatoo/bouquet2/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly define the minimum required permissions for the workflow. Based on the workflow's steps, it primarily interacts with repository contents (e.g., checking out the repository) and does not perform any write operations. Therefore, we will set `contents: read` as the permission. This ensures that the workflow has only the necessary access and adheres to security best practices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
